### PR TITLE
Add extra favicon link

### DIFF
--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -98,6 +98,7 @@ export const Meta = ({ pageTitle, pageDescription, pageImage }: MetaArgs) => {
       <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />
+      <link rel="icon" href="/static/favicon.ico"></link>
       <meta name="apple-mobile-web-app-title" content={conference.Name} />
       <title>{title}</title>
       <meta property="og:title" content={title} />


### PR DESCRIPTION
- Aim to fix favicon display in search engine results

Existing favicon link works ok for Google, 

<img width="902" height="314" alt="image" src="https://github.com/user-attachments/assets/99f4272c-7e6b-4391-8f5e-c8d78e5f5788" />

but not for Bing/DuckDuckGo. eg.

<img width="943" height="340" alt="image" src="https://github.com/user-attachments/assets/5b398a8c-2fe3-4634-bf81-e0b6f9d0521e" />

<img width="986" height="279" alt="image" src="https://github.com/user-attachments/assets/56ffc8b1-0ac9-4245-964c-2b7ece0069a3" />


