### PR TITLE
Don't show wait list text when on sale

### DIFF
--- a/pages/tickets.tsx
+++ b/pages/tickets.tsx
@@ -19,13 +19,12 @@ const TicketPage: NextPage = () => {
     <Main title="Tickets" description={`Purchase tickets for ${conference.Name}`}>
       <h1>Tickets</h1>
 
-      {/* The logic here isn't quite right as it hides the tito link? */}
-      {/* {conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && ( */}
-      <Text>
-        Tickets have sold out, but we are asking people to add themselves to the waitlist just in case any tickets
-        become available.
-      </Text>
-      {/* )} */}
+      {conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && (
+        <Text>
+          Tickets have sold out, but we are asking people to add themselves to the waitlist just in case any tickets become
+          available.
+        </Text>
+      )}
 
       <FaqList faqs={faqs.filter((f) => f.Category === 'tickets')} />
 


### PR DESCRIPTION
Looks like this was changed last year by @flcdrg - I can't recall why. But re-instating the previous logic so we don't show wait list text when tickets go on sale soon for 2025:

https://github.com/dddwa/dddperth-website/commit/2e8f42b90e17910efcdf14e8959b4d5b163335fe