### PR TITLE
Add 'fullTitle' prop so we can override the page title

### DIFF
--- a/components/Sponsors/sponsors.tsx
+++ b/components/Sponsors/sponsors.tsx
@@ -116,7 +116,6 @@ export const Sponsors = ({ sponsors, show, hideUpsell }: SponsorsProps) => {
             ))}
           </Fragment>
         )}
-
       </StyledSponsorsContainer>
 
       {serviceSponsors.length > 0 && (

--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -10,6 +10,7 @@ import Conference from 'config/conference'
 
 interface MetaArgs {
   pageTitle: string
+  pageFullTitle?: string
   pageDescription?: string
   pageImage?: string
 }
@@ -20,7 +21,15 @@ declare global {
   }
 }
 
-const getTitle = (title: string, date: Date, name: string, showDate: boolean, timezone: string) =>
+const getTitle = (
+  title: string,
+  fullTitle: string | undefined,
+  date: Date,
+  name: string,
+  showDate: boolean,
+  timezone: string,
+) =>
+  fullTitle ||
   `${title !== 'Home' ? title + ' - ' : ''}${name}${
     showDate ? ` | ${formatInTimeZone(date, timezone, 'do MMMM yyyy')}` : ''
   }`
@@ -62,7 +71,7 @@ const jsonLd = {
   },
 }
 
-export const Meta = ({ pageTitle, pageDescription, pageImage }: MetaArgs) => {
+export const Meta = ({ pageTitle, pageFullTitle, pageDescription, pageImage }: MetaArgs) => {
   const { conference, appConfig, dates } = useConfig()
   const { pathname } = useRouter()
   const conferenceDates = getConferenceDates(conference, dateTimeProvider.now())
@@ -75,12 +84,21 @@ export const Meta = ({ pageTitle, pageDescription, pageImage }: MetaArgs) => {
     () =>
       getTitle(
         pageTitle,
+        pageFullTitle,
         conference.Date,
         conference.Name,
         !conference.HideDate && !dates.IsComplete,
         conference.TimeZone,
       ),
-    [pageTitle, dates.IsComplete, conference.HideDate, conference.Name, conference.Date, conference.TimeZone],
+    [
+      pageTitle,
+      pageFullTitle,
+      dates.IsComplete,
+      conference.HideDate,
+      conference.Name,
+      conference.Date,
+      conference.TimeZone,
+    ],
   )
 
   React.useEffect(() => {

--- a/config/2023.ts
+++ b/config/2023.ts
@@ -17,7 +17,7 @@ const tagLine = `${name} is an inclusive non-profit conference for the Adelaide 
 
 const hideDate = false
 const ticketPurchasingOptions = TicketPurchasingOptions.OnSale
-const staticDate = '2023-11-23T08:00'
+const staticDate = '2023-11-18T08:00'
 const date = zonedTimeToUtc(staticDate, '+10:30')
 const endDate = add(date, { days: 2, hours: 12 })
 const currentInstance = date.getFullYear()

--- a/config/sponsors.ts
+++ b/config/sponsors.ts
@@ -33,12 +33,9 @@ const goldSponsors: Sponsor[] = [
   },
 ]
 
-const silverSponsors: Sponsor[] = [
-]
+const silverSponsors: Sponsor[] = []
 
-const coffeeCartSponsors: Sponsor[] = [
-
-]
+const coffeeCartSponsors: Sponsor[] = []
 
 const serviceSponsors: Sponsor[] = [
   {
@@ -47,7 +44,7 @@ const serviceSponsors: Sponsor[] = [
     name: 'SixPivot',
     type: SponsorType.Service,
     url: 'https://www.sixpivot.com/',
-    serviceProvided: 'Coffee cart'
+    serviceProvided: 'Coffee cart',
   },
   {
     id: 'intopia',
@@ -55,7 +52,7 @@ const serviceSponsors: Sponsor[] = [
     name: 'Intopia',
     type: SponsorType.Service,
     url: 'https://intopia.digital/',
-    serviceProvided: 'Major prize'
+    serviceProvided: 'Major prize',
   },
   {
     id: 'adelaideUniversity',
@@ -63,7 +60,7 @@ const serviceSponsors: Sponsor[] = [
     name: 'The University of Adelaide',
     type: SponsorType.Service,
     url: 'https://www.adelaide.edu.au/',
-    serviceProvided: 'Venue'
+    serviceProvided: 'Venue',
   },
 ]
 

--- a/layouts/agendaWide.tsx
+++ b/layouts/agendaWide.tsx
@@ -4,6 +4,7 @@ import { StyledAgenda } from './Layouts.styled'
 
 export const Main = ({
   title,
+  fullTitle,
   description,
   image,
   children,
@@ -13,6 +14,7 @@ export const Main = ({
 }: TemplateProps): JSX.Element => (
   <Template
     title={title}
+    fullTitle={fullTitle}
     description={description}
     image={image}
     showHero={showHero}

--- a/layouts/template.tsx
+++ b/layouts/template.tsx
@@ -14,6 +14,7 @@ import { StyledPageBanner } from 'components/PageBanner/PageBanner.styled'
 
 export interface TemplateProps {
   title: string
+  fullTitle?: string
   description?: string
   image?: string
   showHero?: boolean
@@ -25,6 +26,7 @@ export interface TemplateProps {
 export const Template = ({
   children,
   title,
+  fullTitle,
   description,
   image,
   showHero,
@@ -36,7 +38,7 @@ export const Template = ({
 
   return (
     <Fragment>
-      <Meta pageTitle={title} pageDescription={description} pageImage={image} />
+      <Meta pageTitle={title} pageFullTitle={fullTitle} pageDescription={description} pageImage={image} />
       <SkipToContent />
       <NavigationProvider>
         <Header />

--- a/pages/agenda/2023.tsx
+++ b/pages/agenda/2023.tsx
@@ -21,7 +21,15 @@ const AgendaPage: NextPage<AgendaPageProps> = ({ sessions, sessionId }) => {
   const dates = getConferenceDates(Conference2023, currentDate)
 
   return (
-    <Main title="Agenda" description={Conference2023.Name + ' agenda.'}>
+    <Main
+      title="Agenda"
+      fullTitle={
+        '2023 Agenda - ' +
+        Conference2023.Name +
+        ` | ${formatInTimeZone(Conference2023.Date, Conference2023.TimeZone, 'do MMMM yyyy')}`
+      }
+      description={Conference2023.Name + ' agenda.'}
+    >
       <div className="container">
         <h1>{dates.IsComplete && Conference2023.Instance} Agenda</h1>
 

--- a/pages/agenda/2024.tsx
+++ b/pages/agenda/2024.tsx
@@ -21,7 +21,15 @@ const AgendaPage: NextPage<AgendaPageProps> = ({ sessions, sessionId }) => {
   const dates = getConferenceDates(Conference2024, currentDate)
 
   return (
-    <Main title="Agenda" description={Conference2024.Name + ' agenda.'}>
+    <Main
+      title="Agenda"
+      fullTitle={
+        '2024 Agenda - ' +
+        Conference2024.Name +
+        ` | ${formatInTimeZone(Conference2024.StaticDate, Conference2024.TimeZone, 'do MMMM yyyy')}`
+      }
+      description={Conference2024.Name + ' agenda.'}
+    >
       <div className="container">
         <h1>{dates.IsComplete && Conference2024.Instance} Agenda</h1>
 

--- a/pages/tickets.tsx
+++ b/pages/tickets.tsx
@@ -21,8 +21,8 @@ const TicketPage: NextPage = () => {
 
       {conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && (
         <Text>
-          Tickets have sold out, but we are asking people to add themselves to the waitlist just in case any tickets become
-          available.
+          Tickets have sold out, but we are asking people to add themselves to the waitlist just in case any tickets
+          become available.
         </Text>
       )}
 


### PR DESCRIPTION
for the older agenda pages

- If fullTitle/pageFullTitle is not provided then we fall back to the existing functionality