### PR TITLE
Fix formatting of 'All Agendas' list

### DIFF
--- a/components/allAgendas.tsx
+++ b/components/allAgendas.tsx
@@ -22,7 +22,7 @@ const AllAgendas = ({ conference, conferenceInstance, dates }: AllAgendasProps):
               <a>{instance}</a>
             </Link>
           )}
-          {i > 0 && i < conference.PreviousInstances.length ? ' | ' : null}
+          {i >= 0 && i < conference.PreviousInstances.length - 1 ? ' | ' : null}
         </Fragment>
       ))}
       {dates.AgendaPublished && conference.PreviousInstances.length > 0 && ' | '}

--- a/pages/agenda.tsx
+++ b/pages/agenda.tsx
@@ -52,12 +52,14 @@ const AgendaPage: NextPage<AgendaPageProps> = ({ sessions, sessionId }) => {
             </p>
           </React.Fragment>
         )}
+
+        <AllAgendas conference={conference} conferenceInstance={conference.Instance} dates={dates} />
+
         <Sponsors
           show={!conference.HideSponsors}
           hideUpsell={conference.HideSponsorshipUpsell}
           sponsors={conference.Sponsors.filter((s) => s.type === SponsorType.Gold || s.type === SponsorType.Platinum)}
         />
-        <AllAgendas conference={conference} conferenceInstance={conference.Instance} dates={dates} />
       </div>
     </Main>
   )


### PR DESCRIPTION
- Was missing first separator and had extra trailing separator
- Move above sponsors

Before:
<img width="1442" height="628" alt="image" src="https://github.com/user-attachments/assets/fd02c6d1-08ed-4828-bfb5-8d0638662a60" />

After:
<img width="837" height="521" alt="image" src="https://github.com/user-attachments/assets/e9fc51a1-2348-4dc4-9c73-2fd89cb7105f" />
